### PR TITLE
fixed capitalisation of `true` and `false` in post installation zoomed in fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,8 +329,8 @@ This can be caused by Window's Display Scaling feature. This usually is set to a
 - Set the display scaling back to 100% in the Screen Resolution Settings for Windows
 - Edit the mod SSE Display Tweaks.
   - Under `[Render]`
-    - Set Fullscreen to `True`
-    - Set Borderless to `False`
+    - Set Fullscreen to `true`
+    - Set Borderless to `false`
 
 ### Removing the Modlist
 


### PR DESCRIPTION
In the `SSE Display Tweaks` INI file `true` and `false` values are written in all lowercase. Doesn't cause an issue, just more accurate.